### PR TITLE
Removed arrow functions for fixtures

### DIFF
--- a/server/test-fixture/foo/bar/test.js
+++ b/server/test-fixture/foo/bar/test.js
@@ -3,16 +3,16 @@
 const assert = require('assert')
 
 describe(`a top level describe`, function() {
-  it('with a nested it', () => {
+  it('with a nested it', function() {
     assert(true)
   })
 
-  it('with another it', () => {
+  it('with another it', function() {
     assert(true)
   })
 
-  describe("a nested describe", () => {
-    it(`with a mega-nested it`, () => {
+  describe("a nested describe", function() {
+    it(`with a mega-nested it`, function() {
       assert(true)
     })
   })


### PR DESCRIPTION
Mocha recommends avoiding arrow functions since you will lose access to `this` for actions like `this.timeout(10)`. Even if these are just fixtures for testing, I think it is preferable to setup your testing to reflect how potential users will most likely be using the system.

If you have a reason for this, please feel free to close and ignore.